### PR TITLE
update for Swift2/Xcode7

### DIFF
--- a/JSQNotificationObserverKit/JSQNotificationObserverKit.xcodeproj/project.pbxproj
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKit.xcodeproj/project.pbxproj
@@ -177,7 +177,9 @@
 		887D75DB1ABFBD7A00AAE6E7 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Hexed Bits";
 				TargetAttributes = {
 					887D75E31ABFBD7A00AAE6E7 = {
@@ -273,6 +275,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -351,6 +354,7 @@
 				INFOPLIST_FILE = JSQNotificationObserverKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hexedbits.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -368,6 +372,7 @@
 				INFOPLIST_FILE = JSQNotificationObserverKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hexedbits.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -386,6 +391,7 @@
 				);
 				INFOPLIST_FILE = JSQNotificationObserverKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hexedbits.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -399,6 +405,7 @@
 				);
 				INFOPLIST_FILE = JSQNotificationObserverKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.hexedbits.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/JSQNotificationObserverKit/JSQNotificationObserverKit.xcodeproj/xcshareddata/xcschemes/JSQNotificationObserverKit.xcscheme
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKit.xcodeproj/xcshareddata/xcschemes/JSQNotificationObserverKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -37,10 +37,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -62,15 +62,18 @@
             ReferencedContainer = "container:JSQNotificationObserverKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
@@ -85,10 +88,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/JSQNotificationObserverKit/JSQNotificationObserverKit/Info.plist
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKit/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hexedbits.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/JSQNotificationObserverKit/JSQNotificationObserverKit/NotificationObserver.swift
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKit/NotificationObserver.swift
@@ -39,10 +39,10 @@ public struct Notification <Value, Sender: AnyObject> {
 
     ///  Constructs a new notification instance having the specified name and sender.
     ///
-    ///  :param: name   The name of the notification.
-    ///  :param: sender The object sending the notification. The default parameter value is `nil`.
+    ///  - parameter name:   The name of the notification.
+    ///  - parameter sender: The object sending the notification. The default parameter value is `nil`.
     ///
-    ///  :returns: A new `Notification` instance.
+    ///  - returns: A new `Notification` instance.
     public init(name: String, sender: Sender? = nil) {
         self.name = name
         self.sender = sender
@@ -54,11 +54,11 @@ public struct Notification <Value, Sender: AnyObject> {
 ///  Posts the given notification to the specified center.
 ///  This function has the same type parameters as `Notification`, namely `<V, S: AnyObject>`, which restricts the type of value that can be posted.
 ///
-///  :param: notification The notification to post.
-///  :param: value        The data value to be sent with the notification.
-///  :param: center       The notification center from which the notification should be dispatched.
+///  - parameter notification: The notification to post.
+///  - parameter value:        The data value to be sent with the notification.
+///  - parameter center:       The notification center from which the notification should be dispatched.
 ///                       The default parameter value is `NSNotificationCenter.defaultCenter()`.
-public func postNotification<V, S: AnyObject> (notification: Notification<V, S>, #value: V, center: NSNotificationCenter = NSNotificationCenter.defaultCenter()) {
+public func postNotification<V, S: AnyObject> (notification: Notification<V, S>, value: V, center: NSNotificationCenter = NSNotificationCenter.defaultCenter()) {
     center.postNotificationName(notification.name, object: notification.sender, userInfo: userInfo(value))
 }
 
@@ -73,8 +73,8 @@ public final class NotificationObserver <V, S: AnyObject> {
 
     ///  The closure to be called when a notification is received.
     ///
-    ///  :param: value  The data value sent with the notification.
-    ///  :param: sender The object that sent the notification, or `nil` if the notification is not associated with a specific sender.
+    ///  - parameter value:  The data value sent with the notification.
+    ///  - parameter sender: The object that sent the notification, or `nil` if the notification is not associated with a specific sender.
     public typealias Handler = (value: V, sender: S?) -> Void
 
     private let observerProxy: NSObjectProtocol
@@ -86,17 +86,17 @@ public final class NotificationObserver <V, S: AnyObject> {
     ///  Constructs a new `NotificationObserver` instance and immediately registers to begin observing the specified `notification`.
     ///  To unregister this observer and end listening for notifications, dealloc the object by setting it to `nil`.
     ///
-    ///  :param: notification The notification for which to register the observer.
-    ///  :param: queue        The operation queue to which `handler` should be added.
+    ///  - parameter notification: The notification for which to register the observer.
+    ///  - parameter queue:        The operation queue to which `handler` should be added.
     ///                       If `nil`, the block is run synchronously on the posting thread. The default parameter value is `nil`.
-    ///  :param: center       The notification center from which the notification should be dispatched.
+    ///  - parameter center:       The notification center from which the notification should be dispatched.
     ///                       The default parameter value is `NSNotificationCenter.defaultCenter()`.
-    ///  :param: handler      The closure to execute when the notification is received.
+    ///  - parameter handler:      The closure to execute when the notification is received.
     ///
-    ///  :returns: A new `NotificationObserver` instance.
+    ///  - returns: A new `NotificationObserver` instance.
     public init(notification: Notification<V, S>, queue: NSOperationQueue? = nil, center: NSNotificationCenter = NSNotificationCenter.defaultCenter(), handler: Handler) {
         self.center = center
-        observerProxy = center.addObserverForName(notification.name, object: notification.sender, queue: queue, usingBlock: { (notification: NSNotification!) -> Void in
+        observerProxy = center.addObserverForName(notification.name, object: notification.sender, queue: queue, usingBlock: { (notification: NSNotification) -> Void in
             if let value: V = unboxUserInfo(notification.userInfo) {
                 handler(value: value, sender: notification.object as? S)
             }

--- a/JSQNotificationObserverKit/JSQNotificationObserverKitTests/Info.plist
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKitTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.hexedbits.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
This updates the library to make it work with swift 2 and conform to Xcode 7's way of doing doc comments. There are warnings in the unit tests but I can't seem to find a concise way to silence them.
