### PR TITLE
Made postNotification a post function

### DIFF
--- a/JSQNotificationObserverKit/JSQNotificationObserverKit/NotificationObserver.swift
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKit/NotificationObserver.swift
@@ -77,21 +77,17 @@ public struct Notification <Value, Sender: AnyObject> {
         self.sender = sender
     }
 
+    /**
+     Posts the notification to the specified center.
+
+     - parameter value:  The data to be sent with the notification.
+     - parameter center: The notification center from which the notification should be dispatched.
+     The default is `NSNotificationCenter.defaultCenter()`.
+     */
+    public func post(value: Value, center: NSNotificationCenter = .defaultCenter()) {
+        center.postNotificationName(self.name, object: self.sender, userInfo: userInfo(value))
+    }
 }
-
-
-/**
-Posts the given notification to the specified center.
-
-- parameter notification: The notification to post.
-- parameter value:        The data to be sent with the notification.
-- parameter center:       The notification center from which the notification should be dispatched.
-The default is `NSNotificationCenter.defaultCenter()`.
-*/
-public func postNotification<V, S: AnyObject> (notification: Notification<V, S>, value: V, center: NSNotificationCenter = .defaultCenter()) {
-    center.postNotificationName(notification.name, object: notification.sender, userInfo: userInfo(value))
-}
-
 
 /**
 An instance of `NotificationObserver` is responsible for observing notifications.

--- a/JSQNotificationObserverKit/JSQNotificationObserverKitTests/NotificationObserverTests.swift
+++ b/JSQNotificationObserverKit/JSQNotificationObserverKitTests/NotificationObserverTests.swift
@@ -67,7 +67,7 @@ class NotificationObserverTests: XCTestCase {
         XCTAssertNotNil(observer)
 
         // WHEN: the notification is posted with an empty tuple and no sender
-        postNotification(notif, value: ())
+        notif.post(())
 
         // THEN: the observer receives the notification and executes its handler
         self.waitForExpectationsWithTimeout(timeout, handler: { (error) in
@@ -95,7 +95,7 @@ class NotificationObserverTests: XCTestCase {
         XCTAssertNotNil(observer)
 
         // WHEN: the notification is posted with userInfo and no sender
-        postNotification(notif, value: userInfo)
+        notif.post(userInfo)
 
         // THEN: the observer receives the notification and executes its handler
         self.waitForExpectationsWithTimeout(timeout, handler: { (error) in
@@ -123,7 +123,7 @@ class NotificationObserverTests: XCTestCase {
         XCTAssertNotNil(observer)
 
         // WHEN: the notification is posted with userInfo
-        postNotification(notif, value: userInfo)
+        notif.post(userInfo)
 
         // THEN: the observer receives the notification and executes its handler
         self.waitForExpectationsWithTimeout(timeout, handler: { (error) in
@@ -150,7 +150,7 @@ class NotificationObserverTests: XCTestCase {
         XCTAssertNotNil(observer)
 
         // WHEN: the notification is posted
-        postNotification(notification, value: fakeValue)
+        notification.post(fakeValue)
 
         // THEN: the observer receives the notification and executes its handler
         self.waitForExpectationsWithTimeout(timeout, handler: { (error) in
@@ -176,7 +176,7 @@ class NotificationObserverTests: XCTestCase {
         XCTAssertNotNil(observer)
 
         // WHEN: the notification is posted without a specific sender
-        postNotification(notification, value: fakeValue)
+        notification.post(fakeValue)
 
         // THEN: the observer receives the notification and executes its handler
         self.waitForExpectationsWithTimeout(timeout, handler: { (error) in
@@ -201,7 +201,7 @@ class NotificationObserverTests: XCTestCase {
         XCTAssertNotNil(observer)
 
         // WHEN: the notification is posted without a specific sender
-        postNotification(notification, value: nil)
+        notification.post(nil)
 
         // THEN: the observer receives the notification and executes its handler
         self.waitForExpectationsWithTimeout(timeout, handler: { (error) in
@@ -251,7 +251,7 @@ class NotificationObserverTests: XCTestCase {
         observer = nil
         
         // WHEN: the notification is posted after the observer is dealloc'd
-        postNotification(notification, value: fakeValue)
+        notification.post(fakeValue)
         
         // THEN: the observer does not receive the notification and does not execute its handler
         XCTAssertFalse(didCallHandler)


### PR DESCRIPTION
#19
- Removed postNotification as a global function and turned it into a 'post' function on the notification object.
- Updated unit tests accordingly.
